### PR TITLE
Retain generated PDF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore LaTeX intermediate and output files
+*.aux
+*.log
+*.toc
+*.out
+*.synctex.gz
+*.fdb_latexmk
+*.fls


### PR DESCRIPTION
## Summary
- remove `*.pdf` from `.gitignore` so generated PDFs can be versioned

## Testing
- `git status --short`
